### PR TITLE
* Fixed Werror pragma position in jpeg_hal_unit.cpp

### DIFF
--- a/exynos4/hal/include/FimgApi.h
+++ b/exynos4/hal/include/FimgApi.h
@@ -18,6 +18,10 @@
 **
 */
 
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
 #ifndef FIMG_API_H
 #define FIMG_API_H
 

--- a/exynos4/hal/libfimg4x/FimgApi.cpp
+++ b/exynos4/hal/libfimg4x/FimgApi.cpp
@@ -17,6 +17,11 @@
 **
 */
 
+#pragma clang diagnostic ignored "-Wsign-compare"
+#pragma clang diagnostic ignored "-Wformat"
+/* C++11 violation */
+#pragma clang diagnostic ignored "-Wwritable-strings"
+
 #define LOG_NDEBUG 0
 #define LOG_TAG "SKIA"
 #include <utils/Log.h>

--- a/exynos4/hal/libfimg4x/FimgExynos4.cpp
+++ b/exynos4/hal/libfimg4x/FimgExynos4.cpp
@@ -17,6 +17,10 @@
 **
 */
 
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wmismatched-tags"
+#pragma clang diagnostic ignored "-Wunused-variable"
+
 #define LOG_NDEBUG 0
 #define LOG_TAG "FimgExynos4"
 #include <utils/Log.h>

--- a/exynos4/hal/libhwjpeg/jpeg_hal_unit.cpp
+++ b/exynos4/hal/libhwjpeg/jpeg_hal_unit.cpp
@@ -16,6 +16,8 @@
 
 #define LOG_TAG "libhwjpeg"
 
+#pragma clang diagnostic ignored "-Wunused-function"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -34,8 +36,6 @@
 #include <log/log.h>
 
 #include "jpeg_hal.h"
-
-#pragma clang diagnostic ignored "-Wunused-function"
 
 #ifdef JPEG_PERF_MEAS
 unsigned long measure_time(struct timeval *start, struct timeval *stop)

--- a/ril/libsecril-client-sap/secril-client-sap.cpp
+++ b/ril/libsecril-client-sap/secril-client-sap.cpp
@@ -16,6 +16,8 @@
 
 #define LOG_TAG "SapClient"
 
+#pragma clang diagnostic ignored "-Wunused-variable"
+
 #include <binder/Parcel.h>
 #include <telephony/ril.h>
 #include <cutils/record_stream.h>


### PR DESCRIPTION
Fixes the following error (Log in https://paste.fedoraproject.org/paste/4ouL59vmfvh4ePpXk5Vb1A):

```
[leonardo@manauara Chromos_LOS16]$ make -j1 showcommands bacon 2>&1 | fpaste -t "20190318 Chromos_LOS16 - make -j1 showcommands bacon 2>&1"
Uploading (34.5KiB)...
https://paste.fedoraproject.org/paste/4ouL59vmfvh4ePpXk5Vb1A
[leonardo@manauara Chromos_LOS16]$ ls
android                        art       bootstrap.bash  cts         development  frameworks  libcore          lineage-sdk  packages          prebuilts  test       vendor
Android.bp                     bionic    build           dalvik      device       hardware    libnativehelper  Makefile     pdk               sdk        toolchain
android_local_manifests_i9300  bootable  compatibility   developers  external     kernel      lineage          out          platform_testing  system     tools
[leonardo@manauara Chromos_LOS16]$ 
```

Also reported at https://forum.xda-developers.com/showpost.php?p=79148995&postcount=157